### PR TITLE
refactor engine.py

### DIFF
--- a/moban/engine.py
+++ b/moban/engine.py
@@ -108,10 +108,9 @@ class Engine(object):
 
     def _render_with_finding_template_first(self, template_file_index):
         for (template_file, data_output_pairs) in template_file_index.items():
-            template = self.jj2_environment.get_template(template_file)
             for (data_file, output) in data_output_pairs:
                 data = self.context.get_data(data_file)
-                flag = self._apply_template(template, data, output)
+                flag = self._apply_template(template_file, data, output)
                 if flag:
                     reporter.report_templating(template_file, output)
                     self.__templated_count += 1
@@ -121,25 +120,25 @@ class Engine(object):
         for (data_file, template_output_pairs) in data_file_index.items():
             data = self.context.get_data(data_file)
             for (template_file, output) in template_output_pairs:
-                template = self.jj2_environment.get_template(template_file)
-                flag = self._apply_template(template, data, output)
+                flag = self._apply_template(template_file, data, output)
                 if flag:
                     reporter.report_templating(template_file, output)
                     self.__templated_count += 1
                 self.__file_count += 1
 
-    def _apply_template(self, template, data, output):
+    def _apply_template(self, template_file, data, output):
+        template = self.jj2_environment.get_template(template_file)
         rendered_content = template.render(**data)
         rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
         rendered_content = rendered_content.encode("utf-8")
         flag = HASH_STORE.is_file_changed(
-            output, rendered_content, template.filename
+            output, rendered_content, os.path.basename(template_file)
         )
         if flag:
             utils.write_file_out(
                 output, rendered_content, strip=False, encode=False
             )
-            utils.file_permissions_copy(template.filename, output)
+            utils.file_permissions_copy(os.path.basename(template_file), output)
         return flag
 
     def _file_permissions_copy(self, template_file, output_file):


### PR DESCRIPTION
This refactor allows template engines to be created  for templates that do not come with a template loader like python's string.Template.

 `_apply_template` function calls  `file_permissions_copy`  and  `is_file_changed`. These two functions require template filename. This is possible when template libraries provide a loader. But in cases like python string.Template where there is no loader and we have to use `open` function this leads to errors.