### PR TITLE
docs/README.rst: Adds missing tutorials links

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -9,6 +9,8 @@ This section covers the use cases for moban. Please check them out individually.
 #. `Single command`_
 #. `Custom configuration`_
 #. `Complex configuration`_
+#. `Use custom jinja2 filter test n global`_
+#. `Pass a folder full of templates`_
 
 .. _Jinja2 command line: level-1-jinja2-cli
 .. _Template inheritance: level-2-template-inheritance
@@ -16,3 +18,5 @@ This section covers the use cases for moban. Please check them out individually.
 .. _Single command: level-4-single-command
 .. _Custom configuration: level-5-custom-configuration
 .. _Complex configuration: level-6-complex-configuration
+.. _Use custom jinja2 filter test n global: level-7-use-custom-jinja2-filter-test-n-global
+.. _Pass a folder full of templates: level-8-pass-a-folder-full-of-templates


### PR DESCRIPTION
Adds links for missing tutorials in README.rst file:
- https://github.com/moremoban/moban/tree/master/docs/level-7-use-custom-jinja2-filter-test-n-global
- https://github.com/moremoban/moban/tree/master/docs/level-8-pass-a-folder-full-of-templates

Closes https://github.com/moremoban/moban/issues/92