### PR TITLE
change .yaml to .yml

### DIFF
--- a/docs/level-2-template-inheritance/README.rst
+++ b/docs/level-2-template-inheritance/README.rst
@@ -13,6 +13,6 @@ Please go to `docs/level-2-template-inheritance`, here is the command to launch 
 
 .. code-block:: bash
 
-    moban -c data.yaml -t a.template
+    moban -c data.yml -t a.template
 
 `a.template` inherits `.moban.td/base.jj2`.


### PR DESCRIPTION
.yml file is present in folder, not '.yaml' file. Hence on running ``moban -c data.yaml -t a.template``, we get an error.