### PR TITLE
Simpler interface for template engine: jinja2, handle bars and for many to come

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,12 @@ release = u'0.3.4'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [    'sphinx.ext.autodoc',    'sphinx.ext.doctest',    'sphinx.ext.intersphinx',    'sphinx.ext.viewcode',]
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -69,7 +74,7 @@ language = 'en'
 exclude_patterns = []
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = None
+pygments_style = 'sphinx'
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -156,24 +161,6 @@ texinfo_documents = [
      author, 'moban', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-# -- Options for Epub output -------------------------------------------------
-
-# Bibliographic Dublin Core info.
-epub_title = project
-
-# The unique identifier of the text. This can be a ISBN number
-# or the project homepage.
-#
-# epub_identifier = ''
-
-# A unique identification for the text.
-#
-# epub_uid = ''
-
-# A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
 
 # -- Extension configuration -------------------------------------------------
 # -- Options for intersphinx extension ---------------------------------------

--- a/docs/extension.rst
+++ b/docs/extension.rst
@@ -42,7 +42,29 @@ template engines, such as marko, haml can be plugged into moban seamless.
 In order plugin other template engines, it is to write a lml plugin. The following
 is an example starting point for any template engine.
 
-.. literalinclude:: ../tests/moban-mako/moban_mako/__init__.py
+.. code::
+
+   @PluginInfo(
+       constants.TEMPLATE_ENGINE_EXTENSION, tags=["file", "extensions", "for", "your", "template"]
+   )
+   class Engine(object):
+       def __init__(self, template_dirs):
+           """
+           A list template directories will be given to your engine class
+           """
+   
+       def get_template(self, template_file):
+           """
+           Given a relative path to your template file, please return a templatable thing that does
+           the templating function in next function below
+           """
+   
+       def apply_template(self, template, data, output):
+            """
+            Given the template object from `get_template` function, and data as python dictionary, 
+            and output as intended output file, please return "utf-8" encoded string.
+            """
+
 
 After you will have finished the engine plugin, you can either place it in `plugin_dir`
 in order to get it loaded, or make an installable python package. In the latter case,

--- a/moban/engine_handlebars.py
+++ b/moban/engine_handlebars.py
@@ -13,8 +13,10 @@ class EngineHandlebars(object):
         self.template_dirs = template_dirs
 
     def get_template(self, template_file):
-        actual_file = utils.get_template_path(self.template_dirs, template_file)
-        with codecs.open(actual_file, "r", encoding='utf-8') as source:
+        actual_file = utils.get_template_path(
+            self.template_dirs, template_file
+        )
+        with codecs.open(actual_file, "r", encoding="utf-8") as source:
             hbr_template = Compiler().compile(source.read())
         return hbr_template
 
@@ -23,4 +25,3 @@ class EngineHandlebars(object):
         rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
         rendered_content = rendered_content.encode("utf-8")
         return rendered_content
-

--- a/moban/engine_handlebars.py
+++ b/moban/engine_handlebars.py
@@ -1,4 +1,4 @@
-import sys
+import codecs
 
 from lml.plugin import PluginInfo
 
@@ -13,14 +13,9 @@ class EngineHandlebars(object):
         self.template_dirs = template_dirs
 
     def get_template(self, template_file):
-        actual_template_file = self.find_template_file(template_file)
-        with open(actual_template_file, "r") as source:
-            if sys.version_info[0] < 3:
-                hbr_template = Compiler().compile(
-                    unicode(source.read())  # noqa: F821
-                )
-            else:
-                hbr_template = Compiler().compile(source.read())
+        actual_file = self.find_template_file(template_file)
+        with codecs.open(actual_file, "r", encoding='utf-8') as source:
+            hbr_template = Compiler().compile(source.read())
         return hbr_template
 
     def apply_template(self, template, data, output):

--- a/moban/engine_handlebars.py
+++ b/moban/engine_handlebars.py
@@ -13,7 +13,7 @@ class EngineHandlebars(object):
         self.template_dirs = template_dirs
 
     def get_template(self, template_file):
-        actual_file = self.find_template_file(template_file)
+        actual_file = utils.get_template_path(self.template_dirs, template_file)
         with codecs.open(actual_file, "r", encoding='utf-8') as source:
             hbr_template = Compiler().compile(source.read())
         return hbr_template
@@ -24,5 +24,3 @@ class EngineHandlebars(object):
         rendered_content = rendered_content.encode("utf-8")
         return rendered_content
 
-    def find_template_file(self, template_file):
-        return utils.get_template_path(self.template_dirs, template_file)

--- a/moban/engine_handlebars.py
+++ b/moban/engine_handlebars.py
@@ -3,51 +3,17 @@ import sys
 from lml.plugin import PluginInfo
 
 import moban.utils as utils
-import moban.reporter as reporter
 import moban.constants as constants
 from moban import plugins
 from pybars import Compiler
 
 
 @PluginInfo(constants.TEMPLATE_ENGINE_EXTENSION, tags=["handlebars", "hbs"])
-class EngineHandlebars(plugins.BaseEngine):
+class EngineHandlebars(object):
+    def __init__(self, template_dirs):
+        self.template_dirs = template_dirs
 
-    def render_to_file(self, template_file, data_file, output_file):
-        data = self.context.get_data(data_file)
-        template_file, template = self._get_hbr_template(template_file)
-        self._apply_template(template_file, template, data, output_file)
-        reporter.report_templating(template_file, output_file)
-
-    def _render_with_finding_template_first(self, template_file_index):
-        for (template_file, data_output_pairs) in template_file_index.items():
-            template_file, template = self._get_hbr_template(template_file)
-            for (data_file, output) in data_output_pairs:
-                data = self.context.get_data(data_file)
-                self._apply_template(template_file, template, data, output)
-                reporter.report_templating(template_file, output)
-                self.templated_count += 1
-                self.file_count += 1
-
-    def _render_with_finding_data_first(self, data_file_index):
-        for (data_file, template_output_pairs) in data_file_index.items():
-            data = self.context.get_data(data_file)
-            for (template_file, output) in template_output_pairs:
-                template_file, template = self._get_hbr_template(template_file)
-                self._apply_template(template_file, template, data, output)
-                reporter.report_templating(template_file, output)
-                self.templated_count += 1
-                self.file_count += 1
-
-    def _apply_template(self, template_file, template, data, output):
-        rendered_content = "".join(template(data))
-        rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
-        rendered_content = rendered_content.encode("utf-8")
-        utils.write_file_out(
-            output, rendered_content, strip=False, encode=False
-        )
-        utils.file_permissions_copy(template_file, output)
-
-    def _get_hbr_template(self, template_file):
+    def get_template(self, template_file):
         actual_template_file = self.find_template_file(template_file)
         with open(actual_template_file, "r") as source:
             if sys.version_info[0] < 3:
@@ -56,7 +22,16 @@ class EngineHandlebars(plugins.BaseEngine):
                 )
             else:
                 hbr_template = Compiler().compile(source.read())
-        return actual_template_file, hbr_template
+        return plugins.Template(actual_template_file, hbr_template)
+
+    def apply_template(self, template, data, output):
+        rendered_content = "".join(template.template(data))
+        rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
+        rendered_content = rendered_content.encode("utf-8")
+        utils.write_file_out(
+            output, rendered_content, strip=False, encode=False
+        )
+        utils.file_permissions_copy(template.abs_path, output)
 
     def find_template_file(self, template_file):
         return utils.get_template_path(self.template_dirs, template_file)

--- a/moban/engine_handlebars.py
+++ b/moban/engine_handlebars.py
@@ -4,7 +4,6 @@ from lml.plugin import PluginInfo
 
 import moban.utils as utils
 import moban.constants as constants
-from moban import plugins
 from pybars import Compiler
 
 
@@ -22,16 +21,13 @@ class EngineHandlebars(object):
                 )
             else:
                 hbr_template = Compiler().compile(source.read())
-        return plugins.Template(actual_template_file, hbr_template)
+        return hbr_template
 
     def apply_template(self, template, data, output):
-        rendered_content = "".join(template.template(data))
+        rendered_content = "".join(template(data))
         rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
         rendered_content = rendered_content.encode("utf-8")
-        utils.write_file_out(
-            output, rendered_content, strip=False, encode=False
-        )
-        utils.file_permissions_copy(template.abs_path, output)
+        return rendered_content
 
     def find_template_file(self, template_file):
         return utils.get_template_path(self.template_dirs, template_file)

--- a/moban/engine_handlebars.py
+++ b/moban/engine_handlebars.py
@@ -20,7 +20,7 @@ class EngineHandlebars(object):
             hbr_template = Compiler().compile(source.read())
         return hbr_template
 
-    def apply_template(self, template, data, output):
+    def apply_template(self, template, data, _):
         rendered_content = "".join(template(data))
         rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
         rendered_content = rendered_content.encode("utf-8")

--- a/moban/jinja2/engine.py
+++ b/moban/jinja2/engine.py
@@ -1,10 +1,7 @@
-import os
-
 from jinja2 import Environment, FileSystemLoader
 from lml.plugin import PluginInfo
 
 import moban.utils as utils
-import moban.reporter as reporter
 import moban.constants as constants
 from moban import plugins
 from moban.utils import get_template_path
@@ -14,10 +11,10 @@ from moban.hashstore import HASH_STORE
 @PluginInfo(
     constants.TEMPLATE_ENGINE_EXTENSION, tags=["jinja2", "jinja", "jj2", "j2"]
 )
-class Engine(plugins.BaseEngine):
-    def __init__(self, template_dirs, context_dirs):
-        super(Engine, self).__init__(template_dirs, context_dirs)
-        template_loader = FileSystemLoader(self.template_dirs)
+class Engine(object):
+    def __init__(self, template_dirs):
+        self.template_dirs = template_dirs
+        template_loader = FileSystemLoader(template_dirs)
         self.jj2_environment = Environment(
             loader=template_loader,
             keep_trailing_newline=True,
@@ -33,67 +30,25 @@ class Engine(plugins.BaseEngine):
         for global_name, dict_obj in plugins.GLOBALS.get_all():
             self.jj2_environment.globals[global_name] = dict_obj
 
-    def render_to_file(self, template_file, data_file, output_file):
-        data = self.context.get_data(data_file)
-        template_file, template = self._get_jinja2_template(template_file)
-        self._apply_template(template_file, template, data, output_file)
-        reporter.report_templating(template_file, output_file)
-
-    def _render_with_finding_template_first(self, template_file_index):
-        for (template_file, data_output_pairs) in template_file_index.items():
-            template_file, template = self._get_jinja2_template(template_file)
-            for (data_file, output) in data_output_pairs:
-                data = self.context.get_data(data_file)
-                flag = self._apply_template(
-                    template_file, template, data, output
-                )
-                if flag:
-                    reporter.report_templating(template_file, output)
-                    self.templated_count += 1
-                self.file_count += 1
-
-    def _render_with_finding_data_first(self, data_file_index):
-        for (data_file, template_output_pairs) in data_file_index.items():
-            data = self.context.get_data(data_file)
-            for (template_file, output) in template_output_pairs:
-                template_file, template = self._get_jinja2_template(
-                    template_file
-                )
-                flag = self._apply_template(
-                    template_file, template, data, output
-                )
-                if flag:
-                    reporter.report_templating(template_file, output)
-                    self.templated_count += 1
-                self.file_count += 1
-
-    def _file_permissions_copy(self, template_file, output_file):
-        true_template_file = template_file
-        for a_template_dir in self.template_dirs:
-            true_template_file = os.path.join(a_template_dir, template_file)
-            if os.path.exists(true_template_file):
-                break
-        utils.file_permissions_copy(true_template_file, output_file)
-
-    def _apply_template(self, template_file, template, data, output):
-        template.globals["__target__"] = output
-        template.globals["__template__"] = template.name
-        rendered_content = template.render(**data)
+    def apply_template(self, template, data, output):
+        template.template.globals["__target__"] = output
+        template.template.globals["__template__"] = template.template.name
+        rendered_content = template.template.render(**data)
         rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
         rendered_content = rendered_content.encode("utf-8")
         flag = HASH_STORE.is_file_changed(
-            output, rendered_content, template_file
+            output, rendered_content, template.abs_path
         )
         if flag:
             utils.write_file_out(
                 output, rendered_content, strip=False, encode=False
             )
-            utils.file_permissions_copy(template_file, output)
+            utils.file_permissions_copy(template.abs_path, output)
         return flag
 
-    def _get_jinja2_template(self, template_file):
+    def get_template(self, template_file):
         actual_template_file = get_template_path(
             self.template_dirs, template_file
         )
         template = self.jj2_environment.get_template(template_file)
-        return actual_template_file, template
+        return plugins.Template(actual_template_file, template)

--- a/moban/jinja2/engine.py
+++ b/moban/jinja2/engine.py
@@ -4,8 +4,6 @@ from lml.plugin import PluginInfo
 import moban.utils as utils
 import moban.constants as constants
 from moban import plugins
-from moban.utils import get_template_path
-from moban.hashstore import HASH_STORE
 
 
 @PluginInfo(
@@ -31,24 +29,13 @@ class Engine(object):
             self.jj2_environment.globals[global_name] = dict_obj
 
     def apply_template(self, template, data, output):
-        template.template.globals["__target__"] = output
-        template.template.globals["__template__"] = template.template.name
-        rendered_content = template.template.render(**data)
+        template.globals["__target__"] = output
+        template.globals["__template__"] = template.name
+        rendered_content = template.render(**data)
         rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
         rendered_content = rendered_content.encode("utf-8")
-        flag = HASH_STORE.is_file_changed(
-            output, rendered_content, template.abs_path
-        )
-        if flag:
-            utils.write_file_out(
-                output, rendered_content, strip=False, encode=False
-            )
-            utils.file_permissions_copy(template.abs_path, output)
-        return flag
+        return rendered_content
 
     def get_template(self, template_file):
-        actual_template_file = get_template_path(
-            self.template_dirs, template_file
-        )
         template = self.jj2_environment.get_template(template_file)
-        return plugins.Template(actual_template_file, template)
+        return template

--- a/moban/jinja2/engine.py
+++ b/moban/jinja2/engine.py
@@ -44,7 +44,7 @@ class Engine(object):
         :return: a jinja2 template
 
         For example:
-            
+
         suppose your current working directory is: /User/moban-pro/ and your
         template folder list is: ['./my-template'], and the given template
         file equals to: 'templates/myfile.jj2', they as a group tells the

--- a/moban/jinja2/engine.py
+++ b/moban/jinja2/engine.py
@@ -11,6 +11,13 @@ from moban import plugins
 )
 class Engine(object):
     def __init__(self, template_dirs):
+        """
+        Contruct a jinja2 template engine
+
+        A list template directories will be given to your engine class
+
+        :param list temp_dirs: a list of template directories
+        """
         self.template_dirs = template_dirs
         template_loader = FileSystemLoader(template_dirs)
         self.jj2_environment = Environment(
@@ -28,14 +35,38 @@ class Engine(object):
         for global_name, dict_obj in plugins.GLOBALS.get_all():
             self.jj2_environment.globals[global_name] = dict_obj
 
+    def get_template(self, template_file):
+        """
+        :param str template_file: the template file name that appeared in moban
+                                  file. It could be a file name, or a relative
+                                  file path with reference to template
+                                  directories.
+        :return: a jinja2 template
+
+        For example:
+            
+        suppose your current working directory is: /User/moban-pro/ and your
+        template folder list is: ['./my-template'], and the given template
+        file equals to: 'templates/myfile.jj2', they as a group tells the
+        template file exists at:
+            '/User/moban-pro/my-template/templates/myfile.jj2'
+        """
+        template = self.jj2_environment.get_template(template_file)
+        return template
+
     def apply_template(self, template, data, output):
+        """
+        It is not expected this function to write content to file system.
+        Please just apply data inside the template and return utf-8 encoded
+        content.
+
+        :param template: a jinja2 template from :class:`.get_template`
+        :param dict data: python data dictionary
+        :param str output: output file name
+        """
         template.globals["__target__"] = output
         template.globals["__template__"] = template.name
         rendered_content = template.render(**data)
         rendered_content = utils.strip_off_trailing_new_lines(rendered_content)
         rendered_content = rendered_content.encode("utf-8")
         return rendered_content
-
-    def get_template(self, template_file):
-        template = self.jj2_environment.get_template(template_file)
-        return template

--- a/moban/main.py
+++ b/moban/main.py
@@ -132,11 +132,10 @@ def handle_command_line(options):
     options = merge(options, constants.DEFAULT_OPTIONS)
     if options[constants.LABEL_TEMPLATE] is None:
         raise exceptions.NoTemplate(constants.ERROR_NO_TEMPLATE)
-    engine_class = plugins.ENGINES.get_engine(
-        options[constants.LABEL_TEMPLATE_TYPE]
-    )
-    engine = engine_class(
-        options[constants.LABEL_TMPL_DIRS], options[constants.LABEL_CONFIG_DIR]
+    engine = plugins.ENGINES.get_engine(
+        options[constants.LABEL_TEMPLATE_TYPE],
+        options[constants.LABEL_TMPL_DIRS],
+        options[constants.LABEL_CONFIG_DIR],
     )
     engine.render_to_file(
         options[constants.LABEL_TEMPLATE],

--- a/moban/mobanfile.py
+++ b/moban/mobanfile.py
@@ -106,8 +106,8 @@ def handle_targets(merged_options, targets):
 
     count = 0
     for template_type in jobs_for_each_engine.keys():
-        engine_class = plugins.ENGINES.get_engine(template_type)
-        engine = engine_class(
+        engine = plugins.ENGINES.get_engine(
+            template_type,
             merged_options[constants.LABEL_TMPL_DIRS],
             merged_options[constants.LABEL_CONFIG_DIR],
         )

--- a/moban/plugins.py
+++ b/moban/plugins.py
@@ -86,6 +86,15 @@ class BaseEngine(object):
     def number_of_templated_files(self):
         return self.templated_count
 
+    def render_to_file(self, template_file, data_file, output_file):
+        data = self.context.get_data(data_file)
+        template = self.engine.get_template(template_file)
+        self.apply_template(template, data, output_file)
+        reporter.report_templating(template_file, output_file)
+
+    def apply_template(self, template, data, output_file):
+        self.engine.apply_template(template, data, output_file)
+
     def render_to_files(self, array_of_param_tuple):
         sta = Strategy(array_of_param_tuple)
         sta.process()
@@ -95,18 +104,12 @@ class BaseEngine(object):
         else:
             self._render_with_finding_template_first(sta.template_file_index)
 
-    def render_to_file(self, template_file, data_file, output_file):
-        data = self.context.get_data(data_file)
-        template = self.engine.get_template(template_file)
-        self.engine.apply_template(template, data, output_file)
-        reporter.report_templating(template_file, output_file)
-
     def _render_with_finding_template_first(self, template_file_index):
         for (template_file, data_output_pairs) in template_file_index.items():
             template = self.engine.get_template(template_file)
             for (data_file, output) in data_output_pairs:
                 data = self.context.get_data(data_file)
-                self.engine.apply_template(template, data, output)
+                self.apply_template(template, data, output)
                 reporter.report_templating(template_file, output)
                 self.templated_count += 1
                 self.file_count += 1
@@ -116,7 +119,7 @@ class BaseEngine(object):
             data = self.context.get_data(data_file)
             for (template_file, output) in template_output_pairs:
                 template = self.engine.get_template(template_file)
-                self.engine.apply_template(template, data, output)
+                self.apply_template(template, data, output)
                 reporter.report_templating(template_file, output)
                 self.templated_count += 1
                 self.file_count += 1

--- a/moban/plugins.py
+++ b/moban/plugins.py
@@ -7,6 +7,7 @@ from lml.plugin import PluginManager
 import moban.reporter as reporter
 from moban import utils, constants, exceptions
 from moban.strategy import Strategy
+from moban.hashstore import HASH_STORE
 
 
 class PluginMixin:
@@ -89,11 +90,25 @@ class BaseEngine(object):
     def render_to_file(self, template_file, data_file, output_file):
         data = self.context.get_data(data_file)
         template = self.engine.get_template(template_file)
-        self.apply_template(template, data, output_file)
-        reporter.report_templating(template_file, output_file)
+        template_abs_path = utils.get_template_path(
+            self.template_dirs, template_file)
+        flag = self.apply_template(
+            template_abs_path, template, data, output_file)
+        if flag:
+            reporter.report_templating(template_file, output_file)
 
-    def apply_template(self, template, data, output_file):
-        self.engine.apply_template(template, data, output_file)
+    def apply_template(self, template_abs_path, template, data, output_file):
+        rendered_content = self.engine.apply_template(
+            template, data, output_file)
+        flag = HASH_STORE.is_file_changed(
+            output_file, rendered_content, template_abs_path
+        )
+        if flag:
+            utils.write_file_out(
+                output_file, rendered_content, strip=False, encode=False
+            )
+            utils.file_permissions_copy(template_abs_path, output_file)
+        return flag
 
     def render_to_files(self, array_of_param_tuple):
         sta = Strategy(array_of_param_tuple)
@@ -107,11 +122,15 @@ class BaseEngine(object):
     def _render_with_finding_template_first(self, template_file_index):
         for (template_file, data_output_pairs) in template_file_index.items():
             template = self.engine.get_template(template_file)
+            template_abs_path = utils.get_template_path(
+                self.template_dirs, template_file)
             for (data_file, output) in data_output_pairs:
                 data = self.context.get_data(data_file)
-                self.apply_template(template, data, output)
-                reporter.report_templating(template_file, output)
-                self.templated_count += 1
+                flag = self.apply_template(
+                    template_abs_path, template, data, output)
+                if flag:
+                    reporter.report_templating(template_file, output)
+                    self.templated_count += 1
                 self.file_count += 1
 
     def _render_with_finding_data_first(self, data_file_index):
@@ -119,9 +138,13 @@ class BaseEngine(object):
             data = self.context.get_data(data_file)
             for (template_file, output) in template_output_pairs:
                 template = self.engine.get_template(template_file)
-                self.apply_template(template, data, output)
-                reporter.report_templating(template_file, output)
-                self.templated_count += 1
+                template_abs_path = utils.get_template_path(
+                    self.template_dirs, template_file)
+                flag = self.apply_template(
+                    template_abs_path, template, data, output)
+                if flag:
+                    reporter.report_templating(template_file, output)
+                    self.templated_count += 1
                 self.file_count += 1
 
 

--- a/moban/plugins.py
+++ b/moban/plugins.py
@@ -1,5 +1,4 @@
 import os
-from collections import namedtuple
 
 from lml.loader import scan_plugins_regex
 from lml.plugin import PluginManager
@@ -58,9 +57,6 @@ class LibraryManager(PluginManager):
     def resource_path_of(self, library_name):
         library = self.get_a_plugin(library_name)
         return library.resources_path
-
-
-Template = namedtuple("Template", ["abs_path", "template"])
 
 
 class BaseEngine(object):

--- a/moban/plugins.py
+++ b/moban/plugins.py
@@ -91,15 +91,18 @@ class BaseEngine(object):
         data = self.context.get_data(data_file)
         template = self.engine.get_template(template_file)
         template_abs_path = utils.get_template_path(
-            self.template_dirs, template_file)
+            self.template_dirs, template_file
+        )
         flag = self.apply_template(
-            template_abs_path, template, data, output_file)
+            template_abs_path, template, data, output_file
+        )
         if flag:
             reporter.report_templating(template_file, output_file)
 
     def apply_template(self, template_abs_path, template, data, output_file):
         rendered_content = self.engine.apply_template(
-            template, data, output_file)
+            template, data, output_file
+        )
         flag = HASH_STORE.is_file_changed(
             output_file, rendered_content, template_abs_path
         )
@@ -123,11 +126,13 @@ class BaseEngine(object):
         for (template_file, data_output_pairs) in template_file_index.items():
             template = self.engine.get_template(template_file)
             template_abs_path = utils.get_template_path(
-                self.template_dirs, template_file)
+                self.template_dirs, template_file
+            )
             for (data_file, output) in data_output_pairs:
                 data = self.context.get_data(data_file)
                 flag = self.apply_template(
-                    template_abs_path, template, data, output)
+                    template_abs_path, template, data, output
+                )
                 if flag:
                     reporter.report_templating(template_file, output)
                     self.templated_count += 1
@@ -139,9 +144,11 @@ class BaseEngine(object):
             for (template_file, output) in template_output_pairs:
                 template = self.engine.get_template(template_file)
                 template_abs_path = utils.get_template_path(
-                    self.template_dirs, template_file)
+                    self.template_dirs, template_file
+                )
                 flag = self.apply_template(
-                    template_abs_path, template, data, output)
+                    template_abs_path, template, data, output
+                )
                 if flag:
                     reporter.report_templating(template_file, output)
                     self.templated_count += 1

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ URL = 'https://github.com/moremoban/moban'
 DOWNLOAD_URL = '%s/archive/0.3.3.tar.gz' % URL
 FILES = ['README.rst', 'CONTRIBUTORS.rst', 'CHANGELOG.rst']
 KEYWORDS = [
-    'python',
     'jinja2',
     'moban',
+    'python'
 ]
 
 CLASSIFIERS = [

--- a/tests/integration_tests/test_command_line_options.py
+++ b/tests/integration_tests/test_command_line_options.py
@@ -16,7 +16,7 @@ class TestCustomOptions:
         )
         self.patcher1.start()
 
-    @patch("moban.jinja2.engine.Engine.render_to_file")
+    @patch("moban.plugins.BaseEngine.render_to_file")
     def test_custom_options(self, fake_template_doer):
         test_args = [
             "moban",
@@ -37,7 +37,7 @@ class TestCustomOptions:
                 "a.jj2", "config.yaml", "moban.output"
             )
 
-    @patch("moban.jinja2.engine.Engine.render_to_file")
+    @patch("moban.plugins.BaseEngine.render_to_file")
     def test_minimal_options(self, fake_template_doer):
         test_args = ["moban", "-c", self.config_file, "-t", "a.jj2"]
         with patch.object(sys, "argv", test_args):
@@ -71,7 +71,7 @@ class TestOptions:
         )
         self.patcher1.start()
 
-    @patch("moban.jinja2.engine.Engine.render_to_file")
+    @patch("moban.plugins.BaseEngine.render_to_file")
     def test_default_options(self, fake_template_doer):
         test_args = ["moban", "-t", "a.jj2"]
         with patch.object(sys, "argv", test_args):
@@ -119,7 +119,7 @@ class TestNoOptions:
         )
         self.patcher1.start()
 
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_single_command(self, fake_template_doer):
         test_args = ["moban"]
         with patch.object(sys, "argv", test_args):
@@ -135,7 +135,7 @@ class TestNoOptions:
                 ],
             )
 
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_single_command_with_a_few_options(self, fake_template_doer):
         test_args = ["moban", "-t", "abc.jj2", "-o", "xyz.output"]
         with patch.object(sys, "argv", test_args):
@@ -152,7 +152,7 @@ class TestNoOptions:
                 ],
             )
 
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_single_command_with_options(self, fake_template_doer):
         test_args = [
             "moban",
@@ -178,7 +178,7 @@ class TestNoOptions:
             )
 
     @raises(Exception)
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_single_command_without_output_option(self, fake_template_doer):
         test_args = ["moban", "-t", "abc.jj2"]
         with patch.object(sys, "argv", test_args):
@@ -207,7 +207,7 @@ class TestNoOptions2:
         )
         self.patcher1.start()
 
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_single_command(self, fake_template_doer):
         test_args = ["moban"]
         with patch.object(sys, "argv", test_args):
@@ -243,7 +243,7 @@ class TestCustomMobanFile:
         )
         self.patcher1.start()
 
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_single_command(self, fake_template_doer):
         test_args = ["moban", "-m", self.config_file]
         with patch.object(sys, "argv", test_args):
@@ -282,7 +282,7 @@ class TestInvalidMobanFile:
         self.config_file = ".moban.yml"
 
     @raises(SystemExit)
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_no_configuration(self, fake_template_doer):
         with open(self.config_file, "w") as f:
             f.write("")
@@ -293,7 +293,7 @@ class TestInvalidMobanFile:
             main()
 
     @raises(SystemExit)
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_no_configuration_2(self, fake_template_doer):
         with open(self.config_file, "w") as f:
             f.write("not: related")
@@ -304,7 +304,7 @@ class TestInvalidMobanFile:
             main()
 
     @raises(SystemExit)
-    @patch("moban.jinja2.engine.Engine.render_to_files")
+    @patch("moban.plugins.BaseEngine.render_to_files")
     def test_no_targets(self, fake_template_doer):
         with open(self.config_file, "w") as f:
             f.write("configuration: test")
@@ -337,7 +337,7 @@ class TestComplexOptions:
         with patch.object(sys, "argv", test_args):
             from moban.main import main
 
-            with patch("moban.jinja2.engine.Engine.render_to_files") as fake:
+            with patch("moban.plugins.BaseEngine.render_to_files") as fake:
                 main()
                 call_args = list(fake.call_args[0][0])
                 eq_(
@@ -360,7 +360,7 @@ class TestTemplateTypeOption:
         with open(self.config_file, "w") as f:
             f.write("hello: world")
 
-    @patch("moban.jinja2.engine.Engine.render_to_file")
+    @patch("moban.plugins.BaseEngine.render_to_file")
     def test_mako_option(self, fake_template_doer):
         test_args = ["moban", "-t", "a.mako"]
         with patch.object(sys, "argv", test_args):

--- a/tests/moban-mako/moban_mako/__init__.py
+++ b/tests/moban-mako/moban_mako/__init__.py
@@ -5,4 +5,5 @@ from moban.constants import TEMPLATE_ENGINE_EXTENSION
 
 @PluginInfo(TEMPLATE_ENGINE_EXTENSION, tags=["mako"])
 class MakoEngine:
-    pass
+    def __init__(self, template_dirs):
+        pass

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5,7 +5,12 @@ from lml.plugin import PluginInfo
 import moban.exceptions as exceptions
 from mock import patch
 from nose.tools import eq_, raises
-from moban.plugins import ENGINES, Context, expand_template_directories
+from moban.plugins import (
+    ENGINES,
+    Context,
+    BaseEngine,
+    expand_template_directories,
+)
 from moban.extensions import jinja_global
 from moban.jinja2.engine import Engine
 from moban.engine_handlebars import EngineHandlebars
@@ -34,33 +39,33 @@ def test_expand_repo_dir(_, __):
 
 
 def test_default_template_type():
-    engine_class = ENGINES.get_engine("jj2")
-    assert engine_class == Engine
+    engine = ENGINES.get_engine("jj2", [], "")
+    assert engine.engine_cls == Engine
 
 
 def test_handlebars_template_type():
-    engine_class = ENGINES.get_engine("hbs")
-    assert engine_class == EngineHandlebars
+    engine = ENGINES.get_engine("hbs", [], "")
+    assert engine.engine_cls == EngineHandlebars
 
 
 def test_default_mako_type():  # fake mako
-    engine_class = ENGINES.get_engine("mako")
-    assert engine_class.__name__ == "MakoEngine"
+    engine = ENGINES.get_engine("mako", [], "")
+    assert engine.engine_cls.__name__ == "MakoEngine"
 
 
 @raises(exceptions.NoThirdPartyEngine)
 def test_unknown_template_type():
-    ENGINES.get_engine("unknown_template_type")
+    ENGINES.get_engine("unknown_template_type", [], "")
 
 
 @raises(exceptions.DirectoryNotFound)
 def test_non_existent_tmpl_directries():
-    Engine("abc", "tests")
+    BaseEngine("abc", "tests", Engine)
 
 
 @raises(exceptions.DirectoryNotFound)
 def test_non_existent_config_directries():
-    Engine("tests", "abc")
+    BaseEngine("tests", "abc", Engine)
 
 
 @raises(exceptions.DirectoryNotFound)
@@ -71,7 +76,7 @@ def test_non_existent_ctx_directries():
 def test_file_tests():
     output = "test.txt"
     path = os.path.join("tests", "fixtures", "jinja_tests")
-    engine = Engine([path], path)
+    engine = BaseEngine([path], path, Engine)
     engine.render_to_file("file_tests.template", "file_tests.yml", output)
     with open(output, "r") as output_file:
         content = output_file.read()
@@ -82,7 +87,7 @@ def test_file_tests():
 def test_handlebars_file_tests():
     output = "test.txt"
     path = os.path.join("tests", "fixtures", "handlebars_tests")
-    engine = EngineHandlebars([path], path)
+    engine = BaseEngine([path], path, EngineHandlebars)
     engine.render_to_file("file_tests.template", "file_tests.json", output)
     with open(output, "r") as output_file:
         content = output_file.read()
@@ -93,7 +98,7 @@ def test_handlebars_file_tests():
 @raises(exceptions.FileNotFound)
 def test_handlebars_template_not_found():
     path = os.path.join("tests", "fixtures", "handlebars_tests")
-    engine = EngineHandlebars([path], path)
+    engine = EngineHandlebars([path])
     engine.find_template_file("thisisnotafile.template")
 
 
@@ -102,7 +107,7 @@ def test_globals():
     test_dict = dict(hello="world")
     jinja_global("test", test_dict)
     path = os.path.join("tests", "fixtures", "globals")
-    engine = Engine([path], path)
+    engine = BaseEngine([path], path, Engine)
     engine.render_to_file("basic.template", "basic.yml", output)
     with open(output, "r") as output_file:
         content = output_file.read()
@@ -113,7 +118,7 @@ def test_globals():
 def test_global_template_variables():
     output = "test.txt"
     path = os.path.join("tests", "fixtures", "globals")
-    engine = Engine([path], path)
+    engine = BaseEngine([path], path, Engine)
     engine.render_to_file("variables.template", "variables.yml", output)
     with open(output, "r") as output_file:
         content = output_file.read()
@@ -124,7 +129,7 @@ def test_global_template_variables():
 def test_nested_global_template_variables():
     output = "test.txt"
     path = os.path.join("tests", "fixtures", "globals")
-    engine = Engine([path], path)
+    engine = BaseEngine([path], path, Engine)
     engine.render_to_file("nested.template", "variables.yml", output)
     with open(output, "r") as output_file:
         content = output_file.read()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -95,13 +95,6 @@ def test_handlebars_file_tests():
     os.unlink(output)
 
 
-@raises(exceptions.FileNotFound)
-def test_handlebars_template_not_found():
-    path = os.path.join("tests", "fixtures", "handlebars_tests")
-    engine = EngineHandlebars([path])
-    engine.find_template_file("thisisnotafile.template")
-
-
 def test_globals():
     output = "globals.txt"
     test_dict = dict(hello="world")

--- a/tests/test_handlebar_engine.py
+++ b/tests/test_handlebar_engine.py
@@ -1,0 +1,14 @@
+import os
+
+from nose.tools import eq_
+from moban.jinja2.engine import Engine
+
+
+def test_handlebars_template_not_found():
+    path = os.path.join("tests", "fixtures", "jinja_tests")
+    engine = Engine([path])
+    template = engine.get_template("file_tests.template")
+    data = dict(test="here")
+    result = engine.apply_template(template, data, None)
+    expected = "yes\nhere".encode("utf-8")
+    eq_(expected, result)

--- a/tests/test_jinja2_engine.py
+++ b/tests/test_jinja2_engine.py
@@ -1,0 +1,14 @@
+import os
+
+from nose.tools import eq_
+from moban.engine_handlebars import EngineHandlebars
+
+
+def test_handlebars_template_not_found():
+    path = os.path.join("tests", "fixtures", "handlebars_tests")
+    engine = EngineHandlebars([path])
+    template = engine.get_template("file_tests.template")
+    data = dict(test="here")
+    result = engine.apply_template(template, data, None)
+    expected = "here".encode("utf-8")
+    eq_(expected, result)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,11 +1,11 @@
 import os
 
 from mock import patch
+from moban.plugins import BaseEngine
 from moban.jinja2.engine import Engine
-from moban.engine_handlebars import EngineHandlebars
 
 
-@patch("moban.jinja2.engine.Engine._render_with_finding_data_first")
+@patch("moban.plugins.BaseEngine._render_with_finding_data_first")
 def test_do_templates_1(_do_templates_with_more_shared_data):
     jobs = [
         ("1.template", "data.yml", "1.output"),
@@ -23,14 +23,14 @@ def test_do_templates_1(_do_templates_with_more_shared_data):
             ("5.template", "6.output"),
         ]
     }
-    engine = Engine(".", ".")
+    engine = BaseEngine(".", ".", Engine)
     engine.render_to_files(jobs)
     _do_templates_with_more_shared_data.assert_called_with(expected)
     if os.path.exists(".moban.hashes"):
         os.unlink(".moban.hashes")
 
 
-@patch("moban.jinja2.engine.Engine._render_with_finding_template_first")
+@patch("moban.plugins.BaseEngine._render_with_finding_template_first")
 def test_do_templates_2(_do_templates_with_more_shared_templates):
     jobs = [
         ("1.template", "data1.yml", "1.output"),
@@ -48,7 +48,7 @@ def test_do_templates_2(_do_templates_with_more_shared_templates):
             ("data5.yml", "6.output"),
         ]
     }
-    engine = Engine(".", ".")
+    engine = BaseEngine(".", ".", Engine)
     engine.render_to_files(jobs)
     _do_templates_with_more_shared_templates.assert_called_with(expected)
     if os.path.exists(".moban.hashes"):
@@ -57,7 +57,7 @@ def test_do_templates_2(_do_templates_with_more_shared_templates):
 
 def test_do_templates_with_more_shared_templates():
     base_dir = os.path.join("tests", "fixtures")
-    engine = Engine(base_dir, os.path.join(base_dir, "config"))
+    engine = BaseEngine(base_dir, os.path.join(base_dir, "config"), Engine)
     engine._render_with_finding_template_first(
         {"a.jj2": [(os.path.join(base_dir, "child.yaml"), "test")]}
     )
@@ -71,93 +71,9 @@ def test_do_templates_with_more_shared_templates():
 
 def test_do_templates_with_more_shared_data():
     base_dir = os.path.join("tests", "fixtures")
-    engine = Engine(base_dir, os.path.join(base_dir, "config"))
+    engine = BaseEngine(base_dir, os.path.join(base_dir, "config"), Engine)
     engine._render_with_finding_data_first(
         {os.path.join(base_dir, "child.yaml"): [("a.jj2", "test")]}
-    )
-    with open("test", "r") as f:
-        content = f.read()
-        assert content == "hello world ox"
-    os.unlink("test")
-    if os.path.exists(".moban.hashes"):
-        os.unlink(".moban.hashes")
-
-
-@patch(
-    "moban.engine_handlebars.EngineHandlebars."
-    "_render_with_finding_data_first"
-)
-def test_do_templates_1_handlebars(_do_templates_with_more_shared_data):
-    jobs = [
-        ("1.template", "data.yml", "1.output"),
-        ("2.template", "data.yml", "2.output"),
-        ("3.template", "data.yml", "3.output"),
-        ("4.template", "data.yml", "4.output"),
-        ("5.template", "data.yml", "6.output"),
-    ]
-    expected = {
-        "data.yml": [
-            ("1.template", "1.output"),
-            ("2.template", "2.output"),
-            ("3.template", "3.output"),
-            ("4.template", "4.output"),
-            ("5.template", "6.output"),
-        ]
-    }
-    engine = EngineHandlebars(".", ".")
-    engine.render_to_files(jobs)
-    _do_templates_with_more_shared_data.assert_called_with(expected)
-    if os.path.exists(".moban.hashes"):
-        os.unlink(".moban.hashes")
-
-
-@patch(
-    "moban.engine_handlebars.EngineHandlebars."
-    "_render_with_finding_template_first"
-)
-def test_do_templates_2_handlebars(_do_templates_with_more_shared_templates):
-    jobs = [
-        ("1.template", "data1.yml", "1.output"),
-        ("1.template", "data2.yml", "2.output"),
-        ("1.template", "data3.yml", "3.output"),
-        ("1.template", "data4.yml", "4.output"),
-        ("1.template", "data5.yml", "6.output"),
-    ]
-    expected = {
-        "1.template": [
-            ("data1.yml", "1.output"),
-            ("data2.yml", "2.output"),
-            ("data3.yml", "3.output"),
-            ("data4.yml", "4.output"),
-            ("data5.yml", "6.output"),
-        ]
-    }
-    engine = EngineHandlebars(".", ".")
-    engine.render_to_files(jobs)
-    _do_templates_with_more_shared_templates.assert_called_with(expected)
-    if os.path.exists(".moban.hashes"):
-        os.unlink(".moban.hashes")
-
-
-def test_do_templates_with_more_shared_templates_handlebars():
-    base_dir = os.path.join("tests", "fixtures")
-    engine = EngineHandlebars(base_dir, os.path.join(base_dir, "config"))
-    engine._render_with_finding_template_first(
-        {"a.handlebars": [(os.path.join(base_dir, "child.json"), "test")]}
-    )
-    with open("test", "r") as f:
-        content = f.read()
-        assert content == "hello world ox"
-    os.unlink("test")
-    if os.path.exists(".moban.hashes"):
-        os.unlink(".moban.hashes")
-
-
-def test_do_templates_with_more_shared_data_handlebars():
-    base_dir = os.path.join("tests", "fixtures")
-    engine = EngineHandlebars(base_dir, os.path.join(base_dir, "config"))
-    engine._render_with_finding_data_first(
-        {os.path.join(base_dir, "child.json"): [("a.handlebars", "test")]}
     )
     with open("test", "r") as f:
         content = f.read()


### PR DESCRIPTION
```
@PluginInfo(
    constants.TEMPLATE_ENGINE_EXTENSION, tags=["file", "extensions", "for", "your", "template"]
)
class Engine(object):
    def __init__(self, template_dirs):
        """
        A list template directories will be given to your engine class
        """

    def get_template(self, template_file):
        """
        Given a relative path to your template file, please return a templatable thing that does
        the templating function in next function below
        """

    def apply_template(self, template, data, output):
         """
         Given the template object from `get_template` function, and data as python dictionary, 
         and output as intended output file, please return "utf-8" encoded string.
         """
```