### PR TITLE
:sparkles: add reporting feature so that if moban take no action, use…

### DIFF
--- a/moban/main.py
+++ b/moban/main.py
@@ -165,6 +165,7 @@ def handle_command_line(options):
         options[constants.LABEL_CONFIG],
         options[constants.LABEL_OUTPUT],
     )
+    engine.report()
     HASH_STORE.save_hashes()
     exit_code = reporter.convert_to_shell_exit_code(
         engine.number_of_templated_files()

--- a/moban/plugins.py
+++ b/moban/plugins.py
@@ -46,6 +46,7 @@ class BaseEngine(object):
         return self.templated_count
 
     def render_to_file(self, template_file, data_file, output_file):
+        self.file_count = 1
         data = self.context.get_data(data_file)
         template = self.engine.get_template(template_file)
         template_abs_path = utils.get_template_path(
@@ -56,6 +57,7 @@ class BaseEngine(object):
         )
         if flag:
             reporter.report_templating(template_file, output_file)
+            self.templated_count += 1
 
     def apply_template(self, template_abs_path, template, data, output_file):
         rendered_content = self.engine.apply_template(

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -123,7 +123,7 @@ Hello, you are not in level 7
             try:
                 main()
             except SystemExit as e:
-                eq_('1', str(e))
+                eq_("1", str(e))
             _verify_content(output, expected)
         os.unlink(output)
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -123,7 +123,7 @@ Hello, you are not in level 7
             try:
                 main()
             except SystemExit as e:
-                pass
+                eq_('1', str(e))
             _verify_content(output, expected)
         os.unlink(output)
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -120,7 +120,10 @@ Hello, you are not in level 7
     def _raw_moban(self, args, folder, expected, output):
         os.chdir(os.path.join("docs", folder))
         with patch.object(sys, "argv", args):
-            main()
+            try:
+                main()
+            except SystemExit as e:
+                pass
             _verify_content(output, expected)
         os.unlink(output)
 


### PR DESCRIPTION
the report case is related to #150 when moban detects that no need to apply templating. 

`$ moban -t abc.jj2 `

change from

```
Info: Both data.yml and /private/tmp/.moban.cd/data.yml does not exist
Warning: Attempting to use environment vars as data...
```

to 
```
Info: Both data.yml and /private/tmp/.moban.cd/data.yml does not exist
Warning: Attempting to use environment vars as data...
No templating
```