### PR TITLE
Single cli output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -470,6 +470,9 @@ cscope.in.out
 cscope.po.out
 
 
+docs/level-1-jinja2-cli/testout
+docs/level-10-moban-dependency-as-git-repo/mytravis.yml
+docs/level-18-user-defined-template-types/b.output
 docs/level-9-moban-dependency-as-pypi-package/mytravis.yml
 docs/misc-1-copying-templates/misc-1-copying/
 docs/misc-1-copying-templates/test-dir/

--- a/.moban.cd/changelog.yml
+++ b/.moban.cd/changelog.yml
@@ -5,7 +5,7 @@ releases:
   - action: Added
     details:
     - "`#234`: Define template parameters on the fly inside `targets` section"
-    - "`#180`: No longer two stastistics will be shown in v0.4.x. legacy copy targets are injected into a normal targets. cli target is made a clear priority."
+    - "`#180`: No longer two statistics will be shown in v0.4.x. legacy copy targets are injected into a normal targets. cli target is made a clear priority."
   date: unreleased
   version: 0.4.2
 - changes:

--- a/.moban.cd/changelog.yml
+++ b/.moban.cd/changelog.yml
@@ -5,7 +5,8 @@ releases:
   - action: Added
     details:
     - "`#234`: Define template parameters on the fly inside `targets` section"
-  date: 01.03.2019
+    - "`#180`: No longer two stastistics will be shown in v0.4.x. legacy copy targets are injected into a normal targets. cli target is made a clear priority."
+  date: unreleased
   version: 0.4.2
 - changes:
   - action: Added

--- a/.moban.d/moban_gitignore.jj2
+++ b/.moban.d/moban_gitignore.jj2
@@ -1,6 +1,9 @@
 {% extends "gitignore.jj2" %}
 
 {% block extra %}
+docs/level-1-jinja2-cli/testout
+docs/level-10-moban-dependency-as-git-repo/mytravis.yml
+docs/level-18-user-defined-template-types/b.output
 docs/level-9-moban-dependency-as-pypi-package/mytravis.yml
 docs/misc-1-copying-templates/misc-1-copying/
 docs/misc-1-copying-templates/test-dir/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Added
 #. `#234 <https://github.com/moremoban/moban/issues/234>`_: Define template
    parameters on the fly inside `targets` section
 #. `#180 <https://github.com/moremoban/moban/issues/180>`_: No longer two
-   stastistics will be shown in v0.4.x. legacy copy targets are injected into a
+   statistics will be shown in v0.4.x. legacy copy targets are injected into a
    normal targets. cli target is made a clear priority.
 
 0.4.1 - 28.02.2019

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Change log
 ================================================================================
 
-0.4.2 - 01.03.2019
+0.4.2 - unreleased
 --------------------------------------------------------------------------------
 
 Added
@@ -9,6 +9,9 @@ Added
 
 #. `#234 <https://github.com/moremoban/moban/issues/234>`_: Define template
    parameters on the fly inside `targets` section
+#. `#180 <https://github.com/moremoban/moban/issues/180>`_: No longer two
+   stastistics will be shown in v0.4.x. legacy copy targets are injected into a
+   normal targets. cli target is made a clear priority.
 
 0.4.1 - 28.02.2019
 --------------------------------------------------------------------------------


### PR DESCRIPTION
strengthens #180

single cli output has been address previously. this PR join legacy copy targets with normal and only targets so that they are executed in the same pipe line.

what's more, code refactoring is done so that cli target is seen as top priority.