### PR TITLE
Revert use of giturlparse

### DIFF
--- a/.moban.cd/moban.yml
+++ b/.moban.cd/moban.yml
@@ -24,7 +24,7 @@ dependencies:
   - appdirs>=1.2.0
   - crayons>= 0.1.0
   - GitPython>=2.0.0
-  - git-url-parse
+  - git-url-parse>=1.2.2
 description: Yet another jinja2 cli command for static text generation
 scm_host: github.com
 lint_command: make lint install_test format install update

--- a/.moban.cd/moban.yml
+++ b/.moban.cd/moban.yml
@@ -24,7 +24,7 @@ dependencies:
   - appdirs>=1.2.0
   - crayons>= 0.1.0
   - GitPython>=2.0.0
-  - giturlparse>=0.9.1
+  - git-url-parse
 description: Yet another jinja2 cli command for static text generation
 scm_host: github.com
 lint_command: make lint install_test format install update

--- a/.moban.d/travis.yml
+++ b/.moban.d/travis.yml
@@ -10,7 +10,6 @@ matrix:
 {%block custom_python_versions%}
 python:
   - &pypy2 pypy2.7-6.0
-  - 3.8-dev
   - 3.7
   - 3.6
   - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ notifications:
   email: false
 python:
   - &pypy2 pypy2.7-6.0
-  - 3.8-dev
   - 3.7
   - 3.6
   - 3.5

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -4,4 +4,4 @@ lml==0.0.9
 appdirs==1.2.0
 crayons== 0.1.0
 GitPython==2.0.0
-git-url-parse
+git-url-parse==1.2.2

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -4,4 +4,4 @@ lml==0.0.9
 appdirs==1.2.0
 crayons== 0.1.0
 GitPython==2.0.0
-giturlparse==0.9.1
+git-url-parse

--- a/moban/repo.py
+++ b/moban/repo.py
@@ -47,7 +47,7 @@ def get_repo_name(repo_url):
     from giturlparse.parser import ParserError
 
     try:
-        repo = giturlparse.parse(repo_url)
+        repo = giturlparse.parse(repo_url.rstrip("/"))
         return repo.name
     except ParserError:
         reporter.report_error_message(

--- a/moban/repo.py
+++ b/moban/repo.py
@@ -44,14 +44,12 @@ def git_clone(requires):
 
 def get_repo_name(repo_url):
     import giturlparse
+    from giturlparse.parser import ParserError
 
     try:
         repo = giturlparse.parse(repo_url)
-        name = repo.repo
-        if name.endswith("/"):
-            name = name[:-1]
-        return name
-    except AttributeError:
+        return repo.name
+    except ParserError:
         reporter.report_error_message(
             constants.MESSAGE_INVALID_GIT_URL % repo_url
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ lml>=0.0.9
 appdirs>=1.2.0
 crayons>= 0.1.0
 GitPython>=2.0.0
-git-url-parse
+git-url-parse>=1.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ lml>=0.0.9
 appdirs>=1.2.0
 crayons>= 0.1.0
 GitPython>=2.0.0
-giturlparse>=0.9.1
+git-url-parse

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ INSTALL_REQUIRES = [
     "appdirs>=1.2.0",
     "crayons>= 0.1.0",
     "GitPython>=2.0.0",
-    "giturlparse>=0.9.1",
+    "git-url-parse",
 ]
 SETUP_COMMANDS = {}
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ INSTALL_REQUIRES = [
     "appdirs>=1.2.0",
     "crayons>= 0.1.0",
     "GitPython>=2.0.0",
-    "git-url-parse",
+    "git-url-parse>=1.2.2",
 ]
 SETUP_COMMANDS = {}
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -125,14 +125,16 @@ class TestGitFunctions:
 
 def test_get_repo_name():
     repos = [
-        "https://github.com/sphinx-doc/sphinx",
+        "https://github.com/repo-abc-def/repo",
         "https://github.com/abc/repo",
         "https://github.com/abc/repo.git",
         "https://github.com/abc/repo/",
-        "git@github.com:moremoban/moban.git",
+        "git@github.com:abc/repo.git",
+        "git@bitbucket.org:abc/repo.git",
+        "git://github.com/abc/repo.git",
     ]
     actual = [get_repo_name(repo) for repo in repos]
-    expected = ["sphinx", "repo", "repo", "repo", "moban"]
+    expected = ["repo"] * len(repos)
     eq_(expected, actual)
 
 


### PR DESCRIPTION
Fixes https://github.com/moremoban/moban/issues/277

As this is *another* breaking change, it should be in 0.5.0 , not in 0.4.x.  The entire 0.4.x series is unusable for anyone who was using `git-url-parse` with 0.3.x, and they should blacklist 0.4.x