### PR TITLE
Fix: Correct action_past_tense assignment in ContentProcessor

### DIFF
--- a/moban/core/content_processor.py
+++ b/moban/core/content_processor.py
@@ -21,7 +21,7 @@ class ContentProcessor(PluginInfo):
         )
         self.action = action
         self.action_continuing_tense = action_continuing_tense
-        self.action_past_tense = action_continuing_tense
+        self.action_past_tense = action_past_tense
 
     def __call__(self, a_content_processor_function):
         continuing_tense = self.action_continuing_tense


### PR DESCRIPTION
## Bug Description

In `ContentProcessor.__init__`, `self.action_past_tense` was incorrectly assigned `self.action_continuing_tense` instead of the `action_past_tense` parameter, causing the past tense to always equal the continuing tense.

## Fix

Changed line 24 from:
```python
self.action_past_tense = action_continuing_tense
```
to:
```python
self.action_past_tense = action_past_tense
```

## Impact

This ensures that the past tense action string is correctly stored and used when displaying template processing status messages.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.